### PR TITLE
Create basic vendor card tiles

### DIFF
--- a/src/components/VendorCardTiles.js
+++ b/src/components/VendorCardTiles.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { Container, Row, Col, Card } from "react-bootstrap";
+
+const images = [
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200",
+  "https://via.placeholder.com/298X200"
+];
+
+function VendorCardTile({ image }) {
+  return (
+    <Card>
+      <Card.Img variant="top" src={image} />
+      <Card.Body>
+        <Card.Title>Card Title</Card.Title>
+        <Card.Text>
+          Some text to describe the card content.
+        </Card.Text>
+      </Card.Body>
+    </Card>
+  );
+}
+
+function VendorCardTiles() {
+  return (
+    <Container>
+      <Row>
+        {images.map((image, index) => (
+          <Col key={index} md={4} lg={3} className="mb-4">
+            <VendorCardTile image={image} />
+          </Col>
+        ))}
+      </Row>
+    </Container>
+  );
+}
+
+export default VendorCardTiles;


### PR DESCRIPTION
Created basic vendor card tiles for main landing/home page, to update with real images and details. Will need to merge with branch 1002-Create-NavBar and 1003-Create-Main-Landing-Page later.